### PR TITLE
refactor: use sge.DPipe for StringConcat

### DIFF
--- a/ibis/backends/base/sqlglot/compiler.py
+++ b/ibis/backends/base/sqlglot/compiler.py
@@ -653,7 +653,7 @@ class SQLGlotCompiler(abc.ABC):
 
     @visit_node.register(ops.StringConcat)
     def visit_StringConcat(self, op, *, arg):
-        return self.f.concat(*arg)
+        return reduce(lambda x, y: sge.DPipe(this=x, expression=y), arg)
 
     @visit_node.register(ops.StringJoin)
     def visit_StringJoin(self, op, *, sep, arg):

--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -420,13 +420,6 @@ class DataFusionCompiler(SQLGlotCompiler):
     def visit_ArrayIndex(self, op, *, arg, index):
         return self.f.array_element(arg, index + self.cast(index >= 0, op.index.dtype))
 
-    @visit_node.register(ops.StringConcat)
-    def visit_StringConcat(self, op, *, arg):
-        any_args_null = (a.is_(NULL) for a in arg)
-        return self.if_(
-            sg.or_(*any_args_null), self.cast(NULL, dt.string), self.f.concat(*arg)
-        )
-
     @visit_node.register(ops.Arbitrary)
     @visit_node.register(ops.ArgMax)
     @visit_node.register(ops.ArgMin)

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -359,10 +359,6 @@ class DuckDBCompiler(SQLGlotCompiler):
         else:
             raise NotImplementedError(f"No available hashing function for {how}")
 
-    @visit_node.register(ops.StringConcat)
-    def visit_StringConcat(self, op, *, arg):
-        return reduce(lambda x, y: sge.DPipe(this=x, expression=y), arg)
-
 
 _SIMPLE_OPS = {
     ops.ArrayPosition: "list_indexof",

--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -390,11 +390,6 @@ class MSSQLCompiler(SQLGlotCompiler):
             )
         )
 
-    @visit_node.register(ops.StringConcat)
-    def visit_StringConcat(self, op, *, arg):
-        any_args_null = (a.is_(NULL) for a in arg)
-        return self.if_(sg.or_(*any_args_null), NULL, self.f.concat(*arg))
-
     @visit_node.register(ops.Any)
     @visit_node.register(ops.All)
     @visit_node.register(ops.ApproxMedian)

--- a/ibis/backends/oracle/compiler.py
+++ b/ibis/backends/oracle/compiler.py
@@ -441,11 +441,6 @@ class OracleCompiler(SQLGlotCompiler):
 
         return sge.Window(this=func, partition_by=group_by, order=order, spec=spec)
 
-    @visit_node.register(ops.StringConcat)
-    def visit_StringConcat(self, op, *, arg):
-        any_args_null = (a.is_(NULL) for a in arg)
-        return self.if_(sg.or_(*any_args_null), NULL, self.f.concat(*arg))
-
     @visit_node.register(ops.Arbitrary)
     @visit_node.register(ops.ArgMax)
     @visit_node.register(ops.ArgMin)

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -170,10 +170,6 @@ class PostgresCompiler(SQLGlotCompiler):
             self.cast(self.f.array(), op.dtype),
         )
 
-    @visit_node.register(ops.StringConcat)
-    def visit_StringConcat(self, op, *, arg):
-        return reduce(lambda x, y: sge.DPipe(this=x, expression=y), arg)
-
     @visit_node.register(ops.ArrayConcat)
     def visit_ArrayConcat(self, op, *, arg):
         return reduce(self.f.array_cat, map(partial(self.cast, to=op.dtype), arg))


### PR DESCRIPTION
The default implementation in the SQLGlot compiler shoud use DPipe.

Exasol still needs it's own visit_StringConcat()
because it doesn't handle NULLs properly